### PR TITLE
Add cross-platform python script to launch AFNI in a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Docker/AFNI/config.ini

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -104,7 +104,13 @@ def launch_xserver():
     """
     Launch X Server if it isn't already running.
     """
-    if(xserver_running()):
+    enable_display = read_config()["enable display"]
+    if enable_display == "True" and not xserver_running():
+        print("Starting X Server")
+        while not xserver_running():
+            start_xserver_process()
+            sleep(2)
+    if xserver_running():
         print("X Server is running")
 def xserver_running():
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -229,6 +229,13 @@ def get_OS():
         return "Mac"
     else:
         return "Linux"
+def read_config():
+    """
+    Returns the config file as a dictionary.
+    """
+    config = configparser.ConfigParser()
+    config.read(CONFIG_NAME)
+    return {key: config["DEFAULT"][key] for key in config["DEFAULT"]}
 
 if __name__ == "__main__":
     main()

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -26,7 +26,7 @@ def main():
 
     launch_container()
 
-# Functions to edit the config file
+# Functions to initialize the config file
 def initialize_config_file():
     """
     Initialize a config file.
@@ -107,13 +107,12 @@ def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
     else:
         config_obj.set(section, option, value)
 
-# Functions to launch an X Server
+# Functions to launch X Server
 def launch_xserver():
     """
     Launch X Server if it isn't already running.
     """
     print(xserver_running())
-
 def xserver_running():
     """
     Returns True if X Server is running.
@@ -127,7 +126,6 @@ def xserver_running():
     elif OS == "Linux":
         pass
     return False
-
 def start_xserver_process():
     """
     Start whatever X Server you have on your OS.

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -171,7 +171,7 @@ def launch_container():
     Launches the docker container.
     """
     docker_args = get_container_args()
-    print("Executing the following command:")
+    print("Executing the following command to launch the container:")
     print(docker_args)
     process = subprocess.Popen(docker_args)
     process.communicate()

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -90,6 +90,8 @@ def OS_default_config():
         }
     
     OS = get_OS()
+    print(f"Using {OS} config")
+
     if OS == "Windows":
         return windows_default_config
     elif OS == "Mac":
@@ -102,12 +104,16 @@ def launch_xserver():
     """
     Launch X Server if it isn't already running.
     """
-    enable_display = read_config()["enable display"]
-    if enable_display == "True" and not xserver_running():
+    enable_display = read_config()["enable display"].lower()
+    
+    if not enable_display == "true":
+        print("'enable display' is disabled in the config")
+    elif not xserver_running():
         print("Starting X Server")
         while not xserver_running():
             start_xserver_process()
             sleep(2)
+
     if xserver_running():
         print("X Server is running")
 def start_xserver_process():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -1,0 +1,162 @@
+import configparser
+import subprocess
+import os
+import platform
+
+CONFIG_NAME = "config.ini"
+
+def main():
+
+    initialize_config_file()
+
+    launch_container()
+
+
+def get_docker_args():
+    """
+    Reads the config file and returns a list of arguments for Docker.
+    """
+    config = configparser.ConfigParser()
+    config.read(CONFIG_NAME)
+    
+    args_list = ["docker",
+                 "run",
+                 "--interactive",
+                 "--tty",
+                 "--rm",
+                 "--name",
+                 config["DEFAULT"]["name"],
+                 "--volume",
+                 config["DEFAULT"]["host directory to read or write to"] + ":" + config["DEFAULT"]["read/write directory in container"],
+                 "--volume",
+                 config["DEFAULT"]["host directory to read from"] + ":" + config["DEFAULT"]["read directory in container"] + ":ro",
+                 "--workdir",
+                 config["DEFAULT"]["working directory"],
+                 "-p",
+                 config["DEFAULT"]["port"],
+    ]
+    
+
+    if config.getboolean("DEFAULT", "enable display") == True:
+        args_list.append("--env")
+        args_list.append(config["DEFAULT"]["display"])
+
+    
+    args_list.append(config["DEFAULT"]["image"])
+    args_list.append("bash")
+
+    return args_list
+
+
+def launch_container():
+    """
+    Launches the docker container.
+    """
+    docker_args = get_docker_args()
+    print("Executing the following command:")
+    print(docker_args)
+    process = subprocess.Popen(docker_args)
+    process.communicate()
+
+
+def initialize_config_file():
+    """
+    Initialize a config file.
+    """
+    # If a config file doesn't exist, make one.
+    if not os.path.exists(CONFIG_NAME):
+        with open(CONFIG_NAME, "w") as config_file:
+            pass
+
+    # Read the config file.
+    config = configparser.ConfigParser()
+    config.read(CONFIG_NAME)
+
+    # If any config values aren't already set, set them.
+    fill_in_config(config)
+
+    # Save our changes to the config file.
+    with open('config.ini', 'w') as config_file:
+        config.write(config_file)
+
+
+def fill_in_config(config_obj):
+    """
+    Fills missing values in our config object.
+    """
+    default_config_dict = get_OS_config_dict()
+    for key, value in default_config_dict.items():
+        set_if_empty(config_obj, key, value)
+
+
+def get_OS():
+    """
+    Returns the operating system.
+    """
+    if "Windows" in platform.platform():
+        return "Windows"
+    elif "Mac" in platform.platform():
+        return "Mac"
+    else:
+        return "Linux"
+
+
+def get_OS_config_dict():
+    """
+    Returns the config dictionary for the current operating system.
+    """
+    windows_config_dict = {"image": "afni/afni",
+                           "name": "afni",
+                           "host directory to read OR write to": "/c/Volumes/volume/",
+                           "read/write directory in container": "/write_host/",
+                           "host directory to read from": "/c/",
+                           "read directory in container": "/read_host/",
+                           "working directory": "/write_host/",
+                           "port": "8889",
+                           "display": "DISPLAY=host.docker.internal:0",
+                           "enable display": "False"}
+
+    mac_config_dict = {"image": "afni/afni",
+                           "name": "afni",
+                           "host directory to read OR write to": "/",
+                           "read/write directory in container": "/write_host/",
+                           "host directory to read from": "/",
+                           "read directory in container": "/read_host/",
+                           "working directory": "/write_host/",
+                           "port": "8889",
+                           "display": "",
+                           "enable display": "False"}
+
+    linux_config_dict = {"image": "afni/afni",
+                           "name": "afni",
+                           "host directory to read OR write to": "/",
+                           "read/write directory in container": "/write_host/",
+                           "host directory to read from": "/",
+                           "read directory in container": "/read_host/",
+                           "working directory": "/write_host/",
+                           "port": "8889",
+                           "display": "",
+                           "enable display": "False"}
+
+    if "Windows" in platform.platform():
+        return windows_config_dict
+    elif "Mac" in platform.platform():
+        return mac_config_dict
+    else:
+        return linux_config_dict
+
+
+def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
+    """
+    Sets an option to the specified value if it doesn't exist.
+
+    Can optionally specify the section of the configparser to search.
+    """
+    if config_obj.has_option(section, option):
+        return
+    else:
+        config_obj.set(section, option, value)
+
+
+if __name__ == "__main__":
+    main()

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -36,7 +36,7 @@ def initialize_config_file():
         config.write(config_file)
 def OS_default_config():
     """
-    Returns the config dictionary for the current operating system.
+    Returns the default config dictionary for the current operating system.
     """
     windows_default_config = {"DEFAULT":
         {"image": "afni/afni",
@@ -65,10 +65,10 @@ def OS_default_config():
         "host directory to read from": "/",
         "read directory in container": "/read_mount/",
         "working directory": "/write_mount/",
-        "docker path": "",
-        "x server path": "",
+        "docker path": "/Applications/Docker.app",
+        "x server path": "X11.app",
         "name of x server process": "",
-        "display": "",
+        "display": "DISPLAY=docker.for.mac.host.internal:0",
         "enable display": "False"}
         }
 
@@ -85,7 +85,7 @@ def OS_default_config():
         "docker path": "",
         "x server path": "",
         "name of x server process": "",
-        "display": "",
+        "display": "DISPLAY=:0",
         "enable display": "False"}
         }
     
@@ -125,6 +125,7 @@ def start_xserver_process():
     if OS == "Windows":
         subprocess.Popen([xserver_path, ":0", "-multiwindow", "-clipboard", "-wgl"])
     elif OS == "Mac":
+        subprocess.Popen("open", "-a", [xserver_path])
         pass
     elif OS == "Linux":
         pass

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -28,12 +28,21 @@ def main():
 
 # Functions to launch an X Server
 def launch_xserver():
+    """
+    Launch X Server if it isn't already running.
+    """
     start_xserver_process()
 
 def xserver_running():
+    """
+    Returns True if X Server is running.
+    """
     pass
 
 def start_xserver_process():
+    """
+    Start whatever X Server you have on your OS.
+    """
     OS = get_OS()
     if OS == "Windows":
         subprocess.Popen([XSERVER_PATH_WINDOWS, ":0", "-multiwindow", "-clipboard", "-wgl"])

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -82,16 +82,20 @@ def OS_default_config():
         "x server path": ""}
         }
 
-    linux_default_config = {"DEFAILT": {"image": "afni/afni",
-                         "name": "afni",
-                         "host directory to read OR write to": "/",
-                         "read/write directory in container": "/write_host/",
-                         "host directory to read from": "/",
-                         "read directory in container": "/read_host/",
-                         "working directory": "/write_host/",
-                         "port": "8889",
-                         "display": "",
-                         "enable display": "False"}}
+    linux_default_config = {"DEFAULT":
+        {"image": "afni/afni",
+        "name": "afni",
+        "host directory to read OR write to": "/",
+        "read/write directory in container": "/write_host/",
+        "host directory to read from": "/",
+        "read directory in container": "/read_host/",
+        "working directory": "/write_host/",
+        "port": "8889",
+        "display": "",
+        "enable display": "False",
+        "docker path": "",
+        "x server path": ""}
+        }
     
     OS = get_OS()
     if OS == "Windows":

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -198,7 +198,7 @@ def get_container_args():
                  config_dict["port"],
                  ]
 
-    if config_dict["enable display"] == "True":
+    if config_dict["enable display"].lower() == "true":
         args_list.append("--env")
         args_list.append(config_dict["display"])
 

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -91,16 +91,6 @@ def get_OS_config_dict():
         return mac_config_dict
     else:
         return linux_config_dict
-def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
-    """
-    Sets an option to the specified value if it doesn't exist.
-
-    Can optionally specify the section of the configparser to search.
-    """
-    if config_obj.has_option(section, option):
-        return
-    else:
-        config_obj.set(section, option, value)
 
 # Functions to launch X Server
 def launch_xserver():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -17,6 +17,15 @@ def main():
     launch_container()
 
 # Functions to launch the container
+def check_docker_running():
+    """
+    Returns true if docker is running.
+    """
+    process = subprocess.run(["docker", "ps"], capture_output=True)
+    if process.returncode != 0:
+        return False
+    else:
+        return True
 def get_docker_args():
     """
     Reads the config file and returns a list of arguments for Docker.

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -2,6 +2,7 @@ import configparser
 import subprocess
 import os
 import platform
+import psutil
 from time import sleep
 
 
@@ -177,7 +178,7 @@ def launch_container():
     """
     Launches the docker container.
     """
-    docker_args = get_docker_args()
+    docker_args = get_container_args()
     print("Executing the following command:")
     print(docker_args)
     process = subprocess.Popen(docker_args)

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -37,9 +37,12 @@ def initialize_config_file():
         with open(CONFIG_NAME, "w") as config_file:
             pass
 
-    # Read the config file.
     config = configparser.ConfigParser()
+
+    # Get default config.
     config.read_dict(get_OS_config_dict())
+
+    # Overwrite default config with config file.
     config.read(CONFIG_NAME)
 
     # Save our changes to the config file.

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -5,9 +5,14 @@ import platform
 
 CONFIG_NAME = "config.ini"
 
+
 def main():
 
     initialize_config_file()
+
+    # TODO: start_docker()
+
+    # TODO: start_xserver()
 
     launch_container()
 
@@ -18,7 +23,7 @@ def get_docker_args():
     """
     config = configparser.ConfigParser()
     config.read(CONFIG_NAME)
-    
+
     args_list = ["docker",
                  "run",
                  "--interactive",
@@ -27,21 +32,21 @@ def get_docker_args():
                  "--name",
                  config["DEFAULT"]["name"],
                  "--volume",
-                 config["DEFAULT"]["host directory to read or write to"] + ":" + config["DEFAULT"]["read/write directory in container"],
+                 config["DEFAULT"]["host directory to read or write to"] +
+                 ":" + config["DEFAULT"]["read/write directory in container"],
                  "--volume",
-                 config["DEFAULT"]["host directory to read from"] + ":" + config["DEFAULT"]["read directory in container"] + ":ro",
+                 config["DEFAULT"]["host directory to read from"] + ":" +
+                 config["DEFAULT"]["read directory in container"] + ":ro",
                  "--workdir",
                  config["DEFAULT"]["working directory"],
                  "-p",
                  config["DEFAULT"]["port"],
-    ]
-    
+                 ]
 
     if config.getboolean("DEFAULT", "enable display") == True:
         args_list.append("--env")
         args_list.append(config["DEFAULT"]["display"])
 
-    
     args_list.append(config["DEFAULT"]["image"])
     args_list.append("bash")
 
@@ -117,26 +122,26 @@ def get_OS_config_dict():
                            "enable display": "False"}
 
     mac_config_dict = {"image": "afni/afni",
-                           "name": "afni",
-                           "host directory to read OR write to": "/",
-                           "read/write directory in container": "/write_host/",
-                           "host directory to read from": "/",
-                           "read directory in container": "/read_host/",
-                           "working directory": "/write_host/",
-                           "port": "8889",
-                           "display": "",
-                           "enable display": "False"}
+                       "name": "afni",
+                       "host directory to read OR write to": "/",
+                       "read/write directory in container": "/write_host/",
+                       "host directory to read from": "/",
+                       "read directory in container": "/read_host/",
+                       "working directory": "/write_host/",
+                       "port": "8889",
+                       "display": "",
+                       "enable display": "False"}
 
     linux_config_dict = {"image": "afni/afni",
-                           "name": "afni",
-                           "host directory to read OR write to": "/",
-                           "read/write directory in container": "/write_host/",
-                           "host directory to read from": "/",
-                           "read directory in container": "/read_host/",
-                           "working directory": "/write_host/",
-                           "port": "8889",
-                           "display": "",
-                           "enable display": "False"}
+                         "name": "afni",
+                         "host directory to read OR write to": "/",
+                         "read/write directory in container": "/write_host/",
+                         "host directory to read from": "/",
+                         "read directory in container": "/read_host/",
+                         "working directory": "/write_host/",
+                         "port": "8889",
+                         "display": "",
+                         "enable display": "False"}
 
     if "Windows" in platform.platform():
         return windows_config_dict

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -8,15 +8,6 @@ from time import sleep
 
 CONFIG_NAME = "config.ini"
 
-DOCKER_PATH_WINDOWS = "C:/Program Files/Docker/Docker/Docker Desktop.exe"
-DOCKER_PATH_MAC = ""
-DOCKER_PATH_LINUX = ""
-
-XSERVER_PATH_WINDOWS = "C:/Program Files/VcXsrv/vcxsrv.exe"
-XSERVER_PATH_MAC = ""
-XSERVER_PATH_MAC = ""
-
-
 def main():
 
     initialize_config_file()

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -42,12 +42,12 @@ def initialize_config_file():
     config.read(CONFIG_NAME)
 
     # If any config values aren't already set, set them.
-    fill_in_config(config)
+    set_unset_values(config)
 
     # Save our changes to the config file.
     with open('config.ini', 'w') as config_file:
         config.write(config_file)
-def fill_in_config(config_obj):
+def set_unset_values(config_obj):
     """
     Fills missing values in our config object.
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -187,8 +187,7 @@ def get_container_args():
     """
     Reads the config file and returns a list of arguments for the container.
     """
-    config = configparser.ConfigParser()
-    config.read(CONFIG_NAME)
+    config_dict = read_config()
 
     args_list = ["docker",
                  "run",
@@ -196,24 +195,23 @@ def get_container_args():
                  "--tty",
                  "--rm",
                  "--name",
-                 config["DEFAULT"]["name"],
+                 config_dict["name"],
                  "--volume",
-                 config["DEFAULT"]["host directory to read or write to"] +
-                 ":" + config["DEFAULT"]["read/write directory in container"],
+                 config_dict["host directory to read or write to"] + ":" + config_dict["read/write directory in container"],
                  "--volume",
-                 config["DEFAULT"]["host directory to read from"] + ":" +
-                 config["DEFAULT"]["read directory in container"] + ":ro",
+                 config_dict["host directory to read from"] + ":" +
+                 config_dict["read directory in container"] + ":ro",
                  "--workdir",
-                 config["DEFAULT"]["working directory"],
+                 config_dict["working directory"],
                  "-p",
-                 config["DEFAULT"]["port"],
+                 config_dict["port"],
                  ]
 
-    if config.getboolean("DEFAULT", "enable display") == True:
+    if config_dict["enable display"] == "True":
         args_list.append("--env")
-        args_list.append(config["DEFAULT"]["display"])
+        args_list.append(config_dict["display"])
 
-    args_list.append(config["DEFAULT"]["image"])
+    args_list.append(config_dict["image"])
     args_list.append("bash")
 
     return args_list

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -107,7 +107,7 @@ def launch_xserver():
     enable_display = read_config()["enable display"].lower()
     
     if not enable_display == "true":
-        print("'enable display' is disabled in the config")
+        print("'enable display' isn't set to 'True' in the config")
     elif not xserver_running():
         print("Starting X Server")
         while not xserver_running():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -51,10 +51,6 @@ def start_xserver_process():
     elif OS == "Linux":
         pass
 
-def set_display_var():
-    pass
-
-
 # Functions to launch the container
 def launch_docker():
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -55,7 +55,8 @@ def OS_default_config():
         "display": "DISPLAY=host.docker.internal:0",
         "enable display": "False",
         "docker path": "C:/Program Files/Docker/Docker/Docker Desktop.exe",
-        "x server path": "C:/Program Files/VcXsrv/vcxsrv.exe"}
+        "x server path": "C:/Program Files/VcXsrv/vcxsrv.exe",
+        "name of x server process": "vcxsrv.exe"}
         }
 
     mac_default_config = {"DEFAULT":
@@ -70,7 +71,8 @@ def OS_default_config():
         "display": "",
         "enable display": "False",
         "docker path": "",
-        "x server path": ""}
+        "x server path": "",
+        "name of x server process": ""}
         }
 
     linux_default_config = {"DEFAULT":
@@ -85,7 +87,8 @@ def OS_default_config():
         "display": "",
         "enable display": "False",
         "docker path": "",
-        "x server path": ""}
+        "x server path": "",
+        "name of x server process": ""}
         }
     
     OS = get_OS()
@@ -107,8 +110,8 @@ def xserver_running():
     """
     Returns True if X Server is running.
     """
-    xserver_path = read_config()["x server path"]
-    if xserver_path in (process.name() for process in psutil.process_iter()):
+    xprocess = read_config()["name of x server process"]
+    if xprocess in (process.name() for process in psutil.process_iter()):
         return True
     else:
         return False

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -143,7 +143,7 @@ def launch_docker():
         print("Starting Docker")
         while not docker_running():
             start_docker_process()
-            sleep(5)
+            sleep(2)
     print("Docker is running")
 def start_docker_process():
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -40,7 +40,7 @@ def initialize_config_file():
     config = configparser.ConfigParser()
 
     # Get default config.
-    config.read_dict(get_OS_config_dict())
+    config.read_dict(OS_default_config())
 
     # Overwrite default config with config file.
     config.read(CONFIG_NAME)
@@ -48,7 +48,7 @@ def initialize_config_file():
     # Save our changes to the config file.
     with open('config.ini', 'w') as config_file:
         config.write(config_file)
-def get_OS_config_dict():
+def OS_default_config():
     """
     Returns the config dictionary for the current operating system.
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -23,11 +23,6 @@ def initialize_config_file():
     """
     Initialize a config file.
     """
-    # If a config file doesn't exist, make one.
-    if not os.path.exists(CONFIG_NAME):
-        with open(CONFIG_NAME, "w") as config_file:
-            pass
-
     config = configparser.ConfigParser()
 
     # Get default config.

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -107,15 +107,6 @@ def launch_xserver():
             sleep(2)
     if xserver_running():
         print("X Server is running")
-def xserver_running():
-    """
-    Returns True if X Server is running.
-    """
-    xprocess = read_config()["name of x server process"]
-    if xprocess in (process.name() for process in psutil.process_iter()):
-        return True
-    else:
-        return False
 def start_xserver_process():
     """
     Start whatever X Server you have on your OS.
@@ -128,6 +119,15 @@ def start_xserver_process():
         pass
     elif OS == "Linux":
         pass
+def xserver_running():
+    """
+    Returns True if X Server is running.
+    """
+    xprocess = read_config()["name of x server process"]
+    if xprocess in (process.name() for process in psutil.process_iter()):
+        return True
+    else:
+        return False
 
 # Functions to launch Docker
 def launch_docker():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -62,7 +62,9 @@ def OS_default_config():
         "working directory": "/write_host/",
         "port": "8889",
         "display": "DISPLAY=host.docker.internal:0",
-        "enable display": "False"}
+        "enable display": "False",
+        "docker path": "C:/Program Files/Docker/Docker/Docker Desktop.exe",
+        "x server path": "C:/Program Files/VcXsrv/vcxsrv.exe"}
         }
 
     mac_default_config = {"DEFAULT":
@@ -75,7 +77,9 @@ def OS_default_config():
         "working directory": "/write_host/",
         "port": "8889",
         "display": "",
-        "enable display": "False"}
+        "enable display": "False",
+        "docker path": "",
+        "x server path": ""}
         }
 
     linux_default_config = {"DEFAILT": {"image": "afni/afni",

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -26,6 +26,87 @@ def main():
 
     launch_container()
 
+# Functions to edit the config file
+def initialize_config_file():
+    """
+    Initialize a config file.
+    """
+    # If a config file doesn't exist, make one.
+    if not os.path.exists(CONFIG_NAME):
+        with open(CONFIG_NAME, "w") as config_file:
+            pass
+
+    # Read the config file.
+    config = configparser.ConfigParser()
+    config.read(CONFIG_NAME)
+
+    # If any config values aren't already set, set them.
+    fill_in_config(config)
+
+    # Save our changes to the config file.
+    with open('config.ini', 'w') as config_file:
+        config.write(config_file)
+def fill_in_config(config_obj):
+    """
+    Fills missing values in our config object.
+    """
+    default_config_dict = get_OS_config_dict()
+    for key, value in default_config_dict.items():
+        set_if_empty(config_obj, key, value)
+def get_OS_config_dict():
+    """
+    Returns the config dictionary for the current operating system.
+    """
+    windows_config_dict = {"image": "afni/afni",
+                           "name": "afni",
+                           "host directory to read OR write to": "/c/Volumes/volume/",
+                           "read/write directory in container": "/write_host/",
+                           "host directory to read from": "/c/",
+                           "read directory in container": "/read_host/",
+                           "working directory": "/write_host/",
+                           "port": "8889",
+                           "display": "DISPLAY=host.docker.internal:0",
+                           "enable display": "False"}
+
+    mac_config_dict = {"image": "afni/afni",
+                       "name": "afni",
+                       "host directory to read OR write to": "/",
+                       "read/write directory in container": "/write_host/",
+                       "host directory to read from": "/",
+                       "read directory in container": "/read_host/",
+                       "working directory": "/write_host/",
+                       "port": "8889",
+                       "display": "",
+                       "enable display": "False"}
+
+    linux_config_dict = {"image": "afni/afni",
+                         "name": "afni",
+                         "host directory to read OR write to": "/",
+                         "read/write directory in container": "/write_host/",
+                         "host directory to read from": "/",
+                         "read directory in container": "/read_host/",
+                         "working directory": "/write_host/",
+                         "port": "8889",
+                         "display": "",
+                         "enable display": "False"}
+
+    if "Windows" in platform.platform():
+        return windows_config_dict
+    elif "Mac" in platform.platform():
+        return mac_config_dict
+    else:
+        return linux_config_dict
+def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
+    """
+    Sets an option to the specified value if it doesn't exist.
+
+    Can optionally specify the section of the configparser to search.
+    """
+    if config_obj.has_option(section, option):
+        return
+    else:
+        config_obj.set(section, option, value)
+
 # Functions to launch an X Server
 def launch_xserver():
     """
@@ -137,87 +218,6 @@ def get_container_args():
     args_list.append("bash")
 
     return args_list
-
-# Functions to edit the config file
-def initialize_config_file():
-    """
-    Initialize a config file.
-    """
-    # If a config file doesn't exist, make one.
-    if not os.path.exists(CONFIG_NAME):
-        with open(CONFIG_NAME, "w") as config_file:
-            pass
-
-    # Read the config file.
-    config = configparser.ConfigParser()
-    config.read(CONFIG_NAME)
-
-    # If any config values aren't already set, set them.
-    fill_in_config(config)
-
-    # Save our changes to the config file.
-    with open('config.ini', 'w') as config_file:
-        config.write(config_file)
-def fill_in_config(config_obj):
-    """
-    Fills missing values in our config object.
-    """
-    default_config_dict = get_OS_config_dict()
-    for key, value in default_config_dict.items():
-        set_if_empty(config_obj, key, value)
-def get_OS_config_dict():
-    """
-    Returns the config dictionary for the current operating system.
-    """
-    windows_config_dict = {"image": "afni/afni",
-                           "name": "afni",
-                           "host directory to read OR write to": "/c/Volumes/volume/",
-                           "read/write directory in container": "/write_host/",
-                           "host directory to read from": "/c/",
-                           "read directory in container": "/read_host/",
-                           "working directory": "/write_host/",
-                           "port": "8889",
-                           "display": "DISPLAY=host.docker.internal:0",
-                           "enable display": "False"}
-
-    mac_config_dict = {"image": "afni/afni",
-                       "name": "afni",
-                       "host directory to read OR write to": "/",
-                       "read/write directory in container": "/write_host/",
-                       "host directory to read from": "/",
-                       "read directory in container": "/read_host/",
-                       "working directory": "/write_host/",
-                       "port": "8889",
-                       "display": "",
-                       "enable display": "False"}
-
-    linux_config_dict = {"image": "afni/afni",
-                         "name": "afni",
-                         "host directory to read OR write to": "/",
-                         "read/write directory in container": "/write_host/",
-                         "host directory to read from": "/",
-                         "read directory in container": "/read_host/",
-                         "working directory": "/write_host/",
-                         "port": "8889",
-                         "display": "",
-                         "enable display": "False"}
-
-    if "Windows" in platform.platform():
-        return windows_config_dict
-    elif "Mac" in platform.platform():
-        return mac_config_dict
-    else:
-        return linux_config_dict
-def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
-    """
-    Sets an option to the specified value if it doesn't exist.
-
-    Can optionally specify the section of the configparser to search.
-    """
-    if config_obj.has_option(section, option):
-        return
-    else:
-        config_obj.set(section, option, value)
 
 # Other functions
 def get_OS():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -31,13 +31,21 @@ def launch_xserver():
     """
     Launch X Server if it isn't already running.
     """
-    start_xserver_process()
+    print(xserver_running())
 
 def xserver_running():
     """
     Returns True if X Server is running.
     """
-    pass
+    OS = get_OS()
+    if OS == "Windows":
+        if XSERVER_PATH_WINDOWS in (process.name() for process in psutil.process_iter()):
+            return True
+    elif OS == "Mac":
+        pass
+    elif OS == "Linux":
+        pass
+    return False
 
 def start_xserver_process():
     """
@@ -51,7 +59,7 @@ def start_xserver_process():
     elif OS == "Linux":
         pass
 
-# Functions to launch the container
+# Functions to launch Docker
 def launch_docker():
     """
     Launches Docker then waits until it's running.
@@ -84,9 +92,20 @@ def docker_running():
         return False
     else:
         return True
-def get_docker_args():
+
+# Functions to launch the container
+def launch_container():
     """
-    Reads the config file and returns a list of arguments for Docker.
+    Launches the docker container.
+    """
+    docker_args = get_docker_args()
+    print("Executing the following command:")
+    print(docker_args)
+    process = subprocess.Popen(docker_args)
+    process.communicate()
+def get_container_args():
+    """
+    Reads the config file and returns a list of arguments for the container.
     """
     config = configparser.ConfigParser()
     config.read(CONFIG_NAME)
@@ -118,15 +137,6 @@ def get_docker_args():
     args_list.append("bash")
 
     return args_list
-def launch_container():
-    """
-    Launches the docker container.
-    """
-    docker_args = get_docker_args()
-    print("Executing the following command:")
-    print(docker_args)
-    process = subprocess.Popen(docker_args)
-    process.communicate()
 
 # Functions to edit the config file
 def initialize_config_file():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -39,26 +39,17 @@ def initialize_config_file():
 
     # Read the config file.
     config = configparser.ConfigParser()
+    config.read_dict(get_OS_config_dict())
     config.read(CONFIG_NAME)
-
-    # If any config values aren't already set, set them.
-    set_unset_values(config)
 
     # Save our changes to the config file.
     with open('config.ini', 'w') as config_file:
         config.write(config_file)
-def set_unset_values(config_obj):
-    """
-    Fills missing values in our config object.
-    """
-    default_config_dict = get_OS_config_dict()
-    for key, value in default_config_dict.items():
-        set_if_empty(config_obj, key, value)
 def get_OS_config_dict():
     """
     Returns the config dictionary for the current operating system.
     """
-    windows_config_dict = {"image": "afni/afni",
+    windows_config_dict = {"DEFAULT" : {"image": "afni/afni",
                            "name": "afni",
                            "host directory to read OR write to": "/c/Volumes/volume/",
                            "read/write directory in container": "/write_host/",
@@ -67,9 +58,9 @@ def get_OS_config_dict():
                            "working directory": "/write_host/",
                            "port": "8889",
                            "display": "DISPLAY=host.docker.internal:0",
-                           "enable display": "False"}
+                           "enable display": "False"}}
 
-    mac_config_dict = {"image": "afni/afni",
+    mac_config_dict = {"DEFAULT": {"image": "afni/afni",
                        "name": "afni",
                        "host directory to read OR write to": "/",
                        "read/write directory in container": "/write_host/",
@@ -78,9 +69,9 @@ def get_OS_config_dict():
                        "working directory": "/write_host/",
                        "port": "8889",
                        "display": "",
-                       "enable display": "False"}
+                       "enable display": "False"}}
 
-    linux_config_dict = {"image": "afni/afni",
+    linux_config_dict = {"DEFAILT": {"image": "afni/afni",
                          "name": "afni",
                          "host directory to read OR write to": "/",
                          "read/write directory in container": "/write_host/",
@@ -89,7 +80,7 @@ def get_OS_config_dict():
                          "working directory": "/write_host/",
                          "port": "8889",
                          "display": "",
-                         "enable display": "False"}
+                         "enable display": "False"}}
 
     if "Windows" in platform.platform():
         return windows_config_dict

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -2,6 +2,7 @@ import configparser
 import subprocess
 import os
 import platform
+from time import sleep
 
 CONFIG_NAME = "config.ini"
 DOCKER_PATH_WINDOWS = "C:/Program Files/Docker/Docker/Docker Desktop.exe"
@@ -20,14 +21,29 @@ def main():
 
 # Functions to launch the container
 def launch_docker():
+    """
+    Launches Docker then waits until it's running.
+    """
+    if not docker_running():
+        print("Starting Docker")
+        while not docker_running():
+            start_docker_process()
+            sleep(5)
+    print("Docker is running")
+def start_docker_process():
+    """
+    Starts the Docker process.
+    """
     OS = get_OS()
     if OS == "Windows":
         subprocess.Popen(DOCKER_PATH_WINDOWS)
+    #TODO
     elif OS == "Mac":
         pass
+    #TODO
     elif OS == "Linux":
         pass
-def check_docker_running():
+def docker_running():
     """
     Returns true if docker is running.
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -110,7 +110,8 @@ def launch_xserver():
     """
     Launch X Server if it isn't already running.
     """
-    print(xserver_running())
+    if(xserver_running()):
+        print("X Server is running")
 def xserver_running():
     """
     Returns True if X Server is running.
@@ -151,15 +152,8 @@ def start_docker_process():
     """
     Starts the Docker process.
     """
-    OS = get_OS()
-    if OS == "Windows":
-        subprocess.Popen(DOCKER_PATH_WINDOWS)
-    #TODO
-    elif OS == "Mac":
-        pass
-    #TODO
-    elif OS == "Linux":
-        pass
+    docker_path = read_config()["docker path"]
+    subprocess.Popen(docker_path)
 def docker_running():
     """
     Returns true if docker is running.

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -4,32 +4,43 @@ import os
 import platform
 from time import sleep
 
+
 CONFIG_NAME = "config.ini"
+
 DOCKER_PATH_WINDOWS = "C:/Program Files/Docker/Docker/Docker Desktop.exe"
 DOCKER_PATH_MAC = ""
 DOCKER_PATH_LINUX = ""
+
 XSERVER_PATH_WINDOWS = "C:/Program Files/VcXsrv/vcxsrv.exe"
 XSERVER_PATH_MAC = ""
 XSERVER_PATH_MAC = ""
+
 
 def main():
 
     initialize_config_file()
 
-    launch_docker()
-
     launch_xserver()
+
+    launch_docker()
 
     launch_container()
 
 # Functions to launch an X Server
 def launch_xserver():
-    OS = get_OS()
-    if OS == "Windows":
-        subprocess.Popen([XSERVER_PATH_WINDOWS, ":0", "-multiwindow", "-clipboard", "-wgl"])
+    start_xserver_process()
 
 def xserver_running():
     pass
+
+def start_xserver_process():
+    OS = get_OS()
+    if OS == "Windows":
+        subprocess.Popen([XSERVER_PATH_WINDOWS, ":0", "-multiwindow", "-clipboard", "-wgl"])
+    elif OS == "Mac":
+        pass
+    elif OS == "Linux":
+        pass
 
 def set_display_var():
     pass

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -8,6 +8,9 @@ CONFIG_NAME = "config.ini"
 DOCKER_PATH_WINDOWS = "C:/Program Files/Docker/Docker/Docker Desktop.exe"
 DOCKER_PATH_MAC = ""
 DOCKER_PATH_LINUX = ""
+XSERVER_PATH_WINDOWS = "C:/Program Files/VcXsrv/vcxsrv.exe"
+XSERVER_PATH_MAC = ""
+XSERVER_PATH_MAC = ""
 
 def main():
 
@@ -15,9 +18,22 @@ def main():
 
     launch_docker()
 
-    # TODO: start_xserver()
+    launch_xserver()
 
     launch_container()
+
+# Functions to launch an X Server
+def launch_xserver():
+    OS = get_OS()
+    if OS == "Windows":
+        subprocess.Popen([XSERVER_PATH_WINDOWS, ":0", "-multiwindow", "-clipboard", "-wgl"])
+
+def xserver_running():
+    pass
+
+def set_display_var():
+    pass
+
 
 # Functions to launch the container
 def launch_docker():

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -52,29 +52,33 @@ def OS_default_config():
     """
     Returns the config dictionary for the current operating system.
     """
-    windows_config_dict = {"DEFAULT" : {"image": "afni/afni",
-                           "name": "afni",
-                           "host directory to read OR write to": "/c/Volumes/volume/",
-                           "read/write directory in container": "/write_host/",
-                           "host directory to read from": "/c/",
-                           "read directory in container": "/read_host/",
-                           "working directory": "/write_host/",
-                           "port": "8889",
-                           "display": "DISPLAY=host.docker.internal:0",
-                           "enable display": "False"}}
+    windows_default_config = {"DEFAULT":
+        {"image": "afni/afni",
+        "name": "afni",
+        "host directory to read OR write to": "/c/Volumes/volume/",
+        "read/write directory in container": "/write_host/",
+        "host directory to read from": "/c/",
+        "read directory in container": "/read_host/",
+        "working directory": "/write_host/",
+        "port": "8889",
+        "display": "DISPLAY=host.docker.internal:0",
+        "enable display": "False"}
+        }
 
-    mac_config_dict = {"DEFAULT": {"image": "afni/afni",
-                       "name": "afni",
-                       "host directory to read OR write to": "/",
-                       "read/write directory in container": "/write_host/",
-                       "host directory to read from": "/",
-                       "read directory in container": "/read_host/",
-                       "working directory": "/write_host/",
-                       "port": "8889",
-                       "display": "",
-                       "enable display": "False"}}
+    mac_default_config = {"DEFAULT":
+        {"image": "afni/afni",
+        "name": "afni",
+        "host directory to read OR write to": "/",
+        "read/write directory in container": "/write_host/",
+        "host directory to read from": "/",
+        "read directory in container": "/read_host/",
+        "working directory": "/write_host/",
+        "port": "8889",
+        "display": "",
+        "enable display": "False"}
+        }
 
-    linux_config_dict = {"DEFAILT": {"image": "afni/afni",
+    linux_default_config = {"DEFAILT": {"image": "afni/afni",
                          "name": "afni",
                          "host directory to read OR write to": "/",
                          "read/write directory in container": "/write_host/",
@@ -84,14 +88,15 @@ def OS_default_config():
                          "port": "8889",
                          "display": "",
                          "enable display": "False"}}
-
-    if "Windows" in platform.platform():
-        return windows_config_dict
-    elif "Mac" in platform.platform():
-        return mac_config_dict
-    else:
-        return linux_config_dict
-
+    
+    OS = get_OS()
+    if OS == "Windows":
+        return windows_default_config
+    elif OS == "Mac":
+        return mac_default_config
+    elif OS == "Linux":
+        return linux_default_config
+    
 # Functions to launch X Server
 def launch_xserver():
     """

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -4,19 +4,29 @@ import os
 import platform
 
 CONFIG_NAME = "config.ini"
-
+DOCKER_PATH_WINDOWS = "C:/Program Files/Docker/Docker/Docker Desktop.exe"
+DOCKER_PATH_MAC = ""
+DOCKER_PATH_LINUX = ""
 
 def main():
 
     initialize_config_file()
 
-    # TODO: start_docker()
+    launch_docker()
 
     # TODO: start_xserver()
 
     launch_container()
 
 # Functions to launch the container
+def launch_docker():
+    OS = get_OS()
+    if OS == "Windows":
+        subprocess.Popen(DOCKER_PATH_WINDOWS)
+    elif OS == "Mac":
+        pass
+    elif OS == "Linux":
+        pass
 def check_docker_running():
     """
     Returns true if docker is running.

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -107,22 +107,19 @@ def xserver_running():
     """
     Returns True if X Server is running.
     """
-    OS = get_OS()
-    if OS == "Windows":
-        if XSERVER_PATH_WINDOWS in (process.name() for process in psutil.process_iter()):
-            return True
-    elif OS == "Mac":
-        pass
-    elif OS == "Linux":
-        pass
-    return False
+    xserver_path = read_config()["x server path"]
+    if xserver_path in (process.name() for process in psutil.process_iter()):
+        return True
+    else:
+        return False
 def start_xserver_process():
     """
     Start whatever X Server you have on your OS.
     """
+    xserver_path = read_config()["x server path"]
     OS = get_OS()
     if OS == "Windows":
-        subprocess.Popen([XSERVER_PATH_WINDOWS, ":0", "-multiwindow", "-clipboard", "-wgl"])
+        subprocess.Popen([xserver_path, ":0", "-multiwindow", "-clipboard", "-wgl"])
     elif OS == "Mac":
         pass
     elif OS == "Linux":

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -174,19 +174,18 @@ def get_container_args():
 
     args_list = ["docker",
                  "run",
-                 "--interactive",
-                 "--tty",
-                 "--rm",
-                 "--name",
+                 "--interactive", # Allow interaction with the container.
+                 "--tty", # Connect the local shell to the container.
+                 "--rm", # Remove the container when it's closed.
+                 "--name", # Set the name of the container.
                  config_dict["name"],
-                 "--volume",
+                 "--volume", # Set the directory to read/write to.
                  config_dict["host directory to read or write to"] + ":" + config_dict["read/write directory in container"],
-                 "--volume",
-                 config_dict["host directory to read from"] + ":" +
-                 config_dict["read directory in container"] + ":ro",
-                 "--workdir",
+                 "--volume", # Set the directory to read from.
+                 config_dict["host directory to read from"] + ":" + config_dict["read directory in container"] + ":ro",
+                 "--workdir", # Set the working directory in the container.
                  config_dict["working directory"],
-                 "-p",
+                 "-p", # Set the port.
                  config_dict["port"],
                  ]
 
@@ -194,8 +193,8 @@ def get_container_args():
         args_list.append("--env")
         args_list.append(config_dict["display"])
 
-    args_list.append(config_dict["image"])
-    args_list.append("bash")
+    args_list.append(config_dict["image"]) # Set the image to run within the container.
+    args_list.append("bash") # Set the program to run within the container.
 
     return args_list
 

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -16,7 +16,7 @@ def main():
 
     launch_container()
 
-
+# Functions to launch the container
 def get_docker_args():
     """
     Reads the config file and returns a list of arguments for Docker.
@@ -51,8 +51,6 @@ def get_docker_args():
     args_list.append("bash")
 
     return args_list
-
-
 def launch_container():
     """
     Launches the docker container.
@@ -63,7 +61,7 @@ def launch_container():
     process = subprocess.Popen(docker_args)
     process.communicate()
 
-
+# Functions to edit the config file
 def initialize_config_file():
     """
     Initialize a config file.
@@ -83,8 +81,6 @@ def initialize_config_file():
     # Save our changes to the config file.
     with open('config.ini', 'w') as config_file:
         config.write(config_file)
-
-
 def fill_in_config(config_obj):
     """
     Fills missing values in our config object.
@@ -92,20 +88,6 @@ def fill_in_config(config_obj):
     default_config_dict = get_OS_config_dict()
     for key, value in default_config_dict.items():
         set_if_empty(config_obj, key, value)
-
-
-def get_OS():
-    """
-    Returns the operating system.
-    """
-    if "Windows" in platform.platform():
-        return "Windows"
-    elif "Mac" in platform.platform():
-        return "Mac"
-    else:
-        return "Linux"
-
-
 def get_OS_config_dict():
     """
     Returns the config dictionary for the current operating system.
@@ -149,8 +131,6 @@ def get_OS_config_dict():
         return mac_config_dict
     else:
         return linux_config_dict
-
-
 def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
     """
     Sets an option to the specified value if it doesn't exist.
@@ -162,6 +142,17 @@ def set_if_empty(config_obj, option: str, value: str, section="DEFAULT"):
     else:
         config_obj.set(section, option, value)
 
+# Other functions
+def get_OS():
+    """
+    Returns the operating system.
+    """
+    if "Windows" in platform.platform():
+        return "Windows"
+    elif "Mac" in platform.platform():
+        return "Mac"
+    else:
+        return "Linux"
 
 if __name__ == "__main__":
     main()

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -44,10 +44,10 @@ def OS_default_config():
         "program to run within container": "bash",
         "port": "8889",
         "host directory to read OR write to": "/c/Volumes/volume/",
-        "read/write directory in container": "/write_host/",
+        "read/write directory in container": "/write_mount/",
         "host directory to read from": "/c/",
-        "read directory in container": "/read_host/",
-        "working directory": "/write_host/",
+        "read directory in container": "/read_mount/",
+        "working directory": "/write_mount/",
         "docker path": "C:/Program Files/Docker/Docker/Docker Desktop.exe",
         "x server path": "C:/Program Files/VcXsrv/vcxsrv.exe",
         "name of x server process": "vcxsrv.exe",
@@ -58,33 +58,35 @@ def OS_default_config():
     mac_default_config = {"DEFAULT":
         {"image": "afni/afni",
         "name": "afni",
-        "host directory to read OR write to": "/",
-        "read/write directory in container": "/write_host/",
-        "host directory to read from": "/",
-        "read directory in container": "/read_host/",
-        "working directory": "/write_host/",
+        "program to run within container": "bash",
         "port": "8889",
-        "display": "",
-        "enable display": "False",
+        "host directory to read OR write to": "/",
+        "read/write directory in container": "/write_mount/",
+        "host directory to read from": "/",
+        "read directory in container": "/read_mount/",
+        "working directory": "/write_mount/",
         "docker path": "",
         "x server path": "",
-        "name of x server process": ""}
+        "name of x server process": "",
+        "display": "",
+        "enable display": "False"}
         }
 
     linux_default_config = {"DEFAULT":
         {"image": "afni/afni",
         "name": "afni",
-        "host directory to read OR write to": "/",
-        "read/write directory in container": "/write_host/",
-        "host directory to read from": "/",
-        "read directory in container": "/read_host/",
-        "working directory": "/write_host/",
+        "program to run within container": "bash",
         "port": "8889",
-        "display": "",
-        "enable display": "False",
+        "host directory to read OR write to": "/",
+        "read/write directory in container": "/write_mount/",
+        "host directory to read from": "/",
+        "read directory in container": "/read_mount/",
+        "working directory": "/write_mount/",
         "docker path": "",
         "x server path": "",
-        "name of x server process": ""}
+        "name of x server process": "",
+        "display": "",
+        "enable display": "False"}
         }
     
     OS = get_OS()

--- a/Docker/AFNI/afni_docker.py
+++ b/Docker/AFNI/afni_docker.py
@@ -41,17 +41,18 @@ def OS_default_config():
     windows_default_config = {"DEFAULT":
         {"image": "afni/afni",
         "name": "afni",
+        "program to run within container": "bash",
+        "port": "8889",
         "host directory to read OR write to": "/c/Volumes/volume/",
         "read/write directory in container": "/write_host/",
         "host directory to read from": "/c/",
         "read directory in container": "/read_host/",
         "working directory": "/write_host/",
-        "port": "8889",
-        "display": "DISPLAY=host.docker.internal:0",
-        "enable display": "False",
         "docker path": "C:/Program Files/Docker/Docker/Docker Desktop.exe",
         "x server path": "C:/Program Files/VcXsrv/vcxsrv.exe",
-        "name of x server process": "vcxsrv.exe"}
+        "name of x server process": "vcxsrv.exe",
+        "display": "DISPLAY=host.docker.internal:0",
+        "enable display": "False"}
         }
 
     mac_default_config = {"DEFAULT":
@@ -194,7 +195,7 @@ def get_container_args():
         args_list.append(config_dict["display"])
 
     args_list.append(config_dict["image"]) # Set the image to run within the container.
-    args_list.append("bash") # Set the program to run within the container.
+    args_list.append(config_dict["program to run within container"]) # Set the program to run within the container.
 
     return args_list
 

--- a/Docker/AFNI/afni_docker_windows.ps1
+++ b/Docker/AFNI/afni_docker_windows.ps1
@@ -137,7 +137,7 @@ if ($enableGUI) {
     Write-Output "The GUI is enabled, which can make the container buggy"
     Write-Output "Please run the container without the GUI unless you're using the AFNI viewer"
     docker run --interactive --tty --rm --name $name --volume $write_mount --volume $read_mount --workdir $workdir -p $p --env $GUI $image bash
-} else {
+} else {a
     Write-Output "The GUI is disabled"
     Write-Output "To enable the GUI, launch this script with the flag -enableGUI"
     docker run --interactive --tty --rm --name $name --volume $write_mount --volume $read_mount --workdir $workdir -p $p $image bash


### PR DESCRIPTION
So far only Windows works, but Mac and Linux should be easily supported in the future. If you launch the script with Python, it'll start an X Server, then Docker, then AFNI in a docker container. The script also reads from a handy dandy config file so you can customize it to your needs.